### PR TITLE
Enable Water Heater On/Off Control

### DIFF
--- a/custom_components/intellicenter/water_heater.py
+++ b/custom_components/intellicenter/water_heater.py
@@ -122,7 +122,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return WaterHeaterEntityFeature.TARGET_TEMPERATURE | WaterHeaterEntityFeature.OPERATION_MODE
+        return WaterHeaterEntityFeature.TARGET_TEMPERATURE | WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.ON_OFF
 
     @property
     def temperature_unit(self):
@@ -186,6 +186,7 @@ class PoolWaterHeater(PoolEntity, WaterHeaterEntity, RestoreEntity):
             if self._lastHeater != NULL_OBJNAM
             else self._heater_list[0]
         )
+        self.requestChanges({self._attribute_key: self._poolObject.onStatus})
         self.requestChanges({HEATER_ATTR: heater})
 
     async def async_turn_off(self) -> None:


### PR DESCRIPTION
These changes enable the usage of the existing water heater on/off functionality.  This way, water heaters can be turned on and off directly through one entity, without of having to go through the additional step of turning on the pool body through a separate switch.

1. The async_turn_on function for water heaters sets the heater to the most recently used operation mode, however it is not possible to call it without the Water Heater Entity ON_OFF feature enabled.
2.  Turning on the water heater doesn't work without first turning on the pool body it is associated with.  Thus we turn the pool object on and then turn on the heater.

